### PR TITLE
Ignore IntelliJ and Gradle output dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.iml
+.idea/
+*.ipr
+*.iws
+.idea_modules/
+
+.gradle
+build/
+!gradle-wrapper.jar


### PR DESCRIPTION
These prevent IntelliJ and Gradle outputs from being accidentally committed.