### PR TITLE
Use Plugin Development Plugin for azure-webapp-plugin

### DIFF
--- a/azure-webapp-gradle-plugin/build.gradle
+++ b/azure-webapp-gradle-plugin/build.gradle
@@ -1,9 +1,10 @@
-group 'com.microsoft.azure'
-version '1.0-SNAPSHOT'
+plugins {
+    id 'java-gradle-plugin'
+    id 'maven'
+}
 
-apply plugin: 'java'
-apply plugin: 'maven'
-
+group = 'com.microsoft.azure'
+version = '1.0-SNAPSHOT'
 sourceCompatibility = 1.8
 
 repositories {
@@ -12,34 +13,23 @@ repositories {
 }
 
 dependencies {
-    compile gradleApi()
     compile 'com.microsoft.azure:azure:1.7.0'
     compile 'commons-net:commons-net:3.6'
     compile 'commons-io:commons-io:2.2'
-    testCompile gradleTestKit()
     testCompile 'junit:junit:4.12'
 }
 
 uploadArchives {
     repositories {
-        mavenDeployer {
-            repository(url: uri('../../Users/elenla.REDMOND/.m2/repository'))
+        mavenLocal()
+    }
+}
+
+gradlePlugin {
+    plugins {
+        azureWebappPlugin {
+            id = 'com.microsoft.azure.azure-webapp-plugin'
+            implementationClass = 'com.microsoft.azure.gradle.webapp.AzureWebappPlugin'
         }
     }
-}
-
-task createClasspathManifest {
-    def outputDir = file("$buildDir/$name")
-
-    inputs.files sourceSets.main.runtimeClasspath
-    outputs.dir outputDir
-
-    doLast {
-        outputDir.mkdirs()
-        file("$outputDir/plugin-classpath.txt").text = sourceSets.main.runtimeClasspath.join("\n")
-    }
-}
-
-dependencies {
-    testRuntime files(createClasspathManifest)
 }

--- a/azure-webapp-gradle-plugin/src/main/resources/META-INF/gradle-plugins/com.microsoft.azure.azurewebapp.properties
+++ b/azure-webapp-gradle-plugin/src/main/resources/META-INF/gradle-plugins/com.microsoft.azure.azurewebapp.properties
@@ -1,1 +1,0 @@
-implementation-class=com.microsoft.azure.gradle.webapp.AzureWebappPlugin

--- a/azure-webapp-gradle-plugin/src/test/java/com/microsoft/azure/gradle/webapp/DeployTaskTaskTest.java
+++ b/azure-webapp-gradle-plugin/src/test/java/com/microsoft/azure/gradle/webapp/DeployTaskTaskTest.java
@@ -9,20 +9,12 @@ import com.microsoft.azure.credentials.AzureCliCredentials;
 import com.microsoft.azure.management.Azure;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Iterator;
-import java.util.stream.Collectors;
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.junit.Assert.assertEquals;
@@ -31,13 +23,6 @@ public class DeployTaskTaskTest {
     @Rule public final TemporaryFolder testProjectDir = new TemporaryFolder();
 //    File projectDir = new File(".\\testProjects\\simpleProject");
     private File projectDir = new File(".\\testProjects\\dockerProject");
-    private URL pluginClasspathResource = getClass().getClassLoader().getResource("plugin-classpath.txt");
-    private Iterable<File> pluginClassPath;
-
-    @Before
-    public void setup() throws IOException {
-        pluginClassPath = Files.lines(Paths.get(pluginClasspathResource.getFile().substring(1, pluginClasspathResource.getFile().length()))).map(File::new).collect(Collectors.toList());
-    }
 
     @Test
     public void testDeployTask() throws IOException {
@@ -47,8 +32,8 @@ public class DeployTaskTaskTest {
         BuildResult result = GradleRunner.create()
                 .withProjectDir(projectDir)
                 .forwardOutput()
-                .withPluginClasspath(pluginClassPath)
                 .withArguments("deploy")
+                .withPluginClasspath()
                 .build();
         assertEquals(result.task(":deploy").getOutcome(), SUCCESS);
     }


### PR DESCRIPTION
This replaces a bunch of Gradle config and resource files by configuring
the java-gradle-plugin.

See https://docs.gradle.org/current/userguide/java_gradle_plugin.html

> Heads up: I am not able to fully verify this change because I could not get the all tests running. (see [build scan](https://scans.gradle.com/s/ca7ry3gbzsdto)) `azure-cli` fails to run on my macOS machine and I could not generate an `azureProfile.json` file within a reasonable time. However, I was able to `install` and run `dockerPushImage` with this change.

Also note that this doesn't cover the functions gradle plugin.

Issue: #1