### PR TITLE
Avoid NullPointerException thrown when some parameter omitted

### DIFF
--- a/azure-webapp-gradle-plugin/src/main/java/com/microsoft/azure/gradle/webapp/DeployTask.java
+++ b/azure-webapp-gradle-plugin/src/main/java/com/microsoft/azure/gradle/webapp/DeployTask.java
@@ -27,6 +27,8 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import static com.microsoft.azure.gradle.webapp.helpers.CommonStringTemplates.PROPERTY_MISSING_TEMPLATE;
+
 public class DeployTask extends DefaultTask implements AuthConfiguration {
     public static final String TASK_NAME = "azureWebappDeploy";
 
@@ -124,6 +126,10 @@ public class DeployTask extends DefaultTask implements AuthConfiguration {
 
                 DeployTarget target;
 
+                if (azureWebAppExtension.getDeployment() == null) {
+                    throw new GradleException(String.format(PROPERTY_MISSING_TEMPLATE, "deployment"));
+                }
+
                 if (azureWebAppExtension.getDeployment().getDeploymentSlot() != null) {
                     final String slotName = azureWebAppExtension.getDeployment().getDeploymentSlot();
                     final DeploymentSlot slot = getDeploymentSlot(app, slotName);
@@ -183,6 +189,9 @@ public class DeployTask extends DefaultTask implements AuthConfiguration {
     @Override
     public Authentication getAuthenticationSettings() {
         Authentication authSetting = azureWebAppExtension.getAuthentication();
+        if (authSetting == null) {
+            throw new GradleException(String.format(PROPERTY_MISSING_TEMPLATE, "authentication"));
+        }
         Map<String, ?> props = getProject().getProperties();
         for (Field f : authSetting.getClass().getDeclaredFields()) {
             try {

--- a/azure-webapp-gradle-plugin/src/main/java/com/microsoft/azure/gradle/webapp/auth/AzureAuthHelper.java
+++ b/azure-webapp-gradle-plugin/src/main/java/com/microsoft/azure/gradle/webapp/auth/AzureAuthHelper.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.Azure.Authenticated;
 import com.microsoft.rest.LogLevel;
 import org.apache.commons.lang3.StringUtils;
+import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 
@@ -98,6 +99,9 @@ public class AzureAuthHelper {
         // check if project has Azure authentication settings in build.gradle
         // or gradle.properties or in environment variables
         final Authentication authSetting = config.getAuthenticationSettings();
+        if (authSetting.getType() == null) {
+            throw new GradleException(String.format(PROPERTY_MISSING_TEMPLATE, "authentication.type"));
+        }
         switch (authSetting.getType()) {
             case FILE:
                 if (authSetting.getFile() != null) {

--- a/azure-webapp-gradle-plugin/src/main/java/com/microsoft/azure/gradle/webapp/handlers/HandlerFactoryImpl.java
+++ b/azure-webapp-gradle-plugin/src/main/java/com/microsoft/azure/gradle/webapp/handlers/HandlerFactoryImpl.java
@@ -66,6 +66,9 @@ public class HandlerFactoryImpl extends HandlerFactory {
             task.getLogger().quiet("No deployment configured, exit.");
             return null;
         }
+        if (deployment.getType() == null) {
+            throw new GradleException(String.format(PROPERTY_MISSING_TEMPLATE, "deployment.type"));
+        }
         switch (deployment.getType()) {
             case NONE:
                 if (task.getAzureWebAppExtension().getAppService().getType() != AppServiceType.DOCKER) {

--- a/azure-webapp-gradle-plugin/src/main/java/com/microsoft/azure/gradle/webapp/handlers/WindowsRuntimeHandlerImpl.java
+++ b/azure-webapp-gradle-plugin/src/main/java/com/microsoft/azure/gradle/webapp/handlers/WindowsRuntimeHandlerImpl.java
@@ -14,6 +14,9 @@ import com.microsoft.azure.management.appservice.OperatingSystem;
 import com.microsoft.azure.management.appservice.WebApp;
 import com.microsoft.azure.management.appservice.WebApp.DefinitionStages.WithCreate;
 import com.microsoft.azure.management.appservice.WebApp.Update;
+import org.gradle.api.GradleException;
+
+import static com.microsoft.azure.gradle.webapp.helpers.CommonStringTemplates.PROPERTY_MISSING_TEMPLATE;
 
 public class WindowsRuntimeHandlerImpl implements RuntimeHandler {
     private DeployTask task;
@@ -29,6 +32,10 @@ public class WindowsRuntimeHandlerImpl implements RuntimeHandler {
         final AppServicePlan plan = WebAppUtils.createOrGetAppServicePlan(task, OperatingSystem.WINDOWS);
         final WithCreate withCreate = WebAppUtils.defineWindowsApp(task, plan);
 
+        if (extension.getAppService().getJavaVersion() == null) {
+            throw new GradleException(String.format(PROPERTY_MISSING_TEMPLATE, "appService.javaVersion"));
+        }
+
         withCreate.withJavaVersion(extension.getAppService().getJavaVersion())
                 .withWebContainer(extension.getAppService().getJavaWebContainer());
         return withCreate;
@@ -37,6 +44,10 @@ public class WindowsRuntimeHandlerImpl implements RuntimeHandler {
     @Override
     public Update updateAppRuntime(final WebApp app) {
         WebAppUtils.assureWindowsWebApp(app);
+
+        if (extension.getAppService().getJavaVersion() == null) {
+            throw new GradleException(String.format(PROPERTY_MISSING_TEMPLATE, "appService.javaVersion"));
+        }
 
         final Update update = app.update();
         update.withJavaVersion(extension.getAppService().getJavaVersion())

--- a/azure-webapp-gradle-plugin/src/main/java/com/microsoft/azure/gradle/webapp/helpers/WebAppUtils.java
+++ b/azure-webapp-gradle-plugin/src/main/java/com/microsoft/azure/gradle/webapp/helpers/WebAppUtils.java
@@ -76,6 +76,10 @@ public class WebAppUtils {
             throws Exception {
         assureWindowsPlan(plan);
 
+        if (task.getAzureWebAppExtension().getAppName() == null) {
+            throw new GradleException(String.format(PROPERTY_MISSING_TEMPLATE, "azureWebapp.appName"));
+        }
+
         final String resourceGroup = task.getAzureWebAppExtension().getResourceGroup();
         final WebApp.DefinitionStages.ExistingWindowsPlanWithGroup existingWindowsPlanWithGroup =  task.getAzureClient().webApps()
                 .define(task.getAzureWebAppExtension().getAppName())


### PR DESCRIPTION
# Abstract

This pull request has a diff which avoids `NullPointerException` is thrown when some parameter is omitted on an `azureWebapp` definition in a `build.gradle` file. Users can know the reason clearly by seeing the concrete error message.

# Behavior that changed

In the latest `master` branch code, if a `authentication` property is omitted, you will see the following output:

```bash
$ gradle azureWebappDeploy

> Task :azureWebappDeploy FAILED
Start deploying to Web App yoichirowa1...
Target Web App doesn't exist. Creating a new one...
com.microsoft.azure.gradle.webapp.handlers.WindowsRuntimeHandlerImpl

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':azureWebappDeploy'.
> java.lang.NullPointerException (no error message)
...
```

After applying this pull request, you will see the following output against same situation:

```bash
$ gradle azureWebappDeploy

> Task :azureWebappDeploy FAILED
Start deploying to Web App yoichirowa1...
Target Web App doesn't exist. Creating a new one...
com.microsoft.azure.gradle.webapp.handlers.WindowsRuntimeHandlerImpl

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':azureWebappDeploy'.
> 'authentication' is not configured in build.gradle.
...
```

# Target properties

In this pull request, the situation at omitted the following properties are supported:

* `azureWebapp.appName`
* `azureWebapp.authentication`
* `azureWebapp.authentication.type`
* `azureWebapp.deployment`
* `azureWebapp.deployment.type`
* `azureWebapp.appService.javaVersion`

# How to check them and output an error message

Basically, to check whether a parameter is omitted or not,

* Check whether the returned value of the target property is `null` or not before the line where accessing to the target property.
* If the returned value is `null`, throw a `GradleException` with an error message including the property name.