### PR TITLE
NullPointerException fix when using Deployment slots + Kotlin DSL compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ plugins {
 deploymentType | false | Deployment type - one of {FTP, WAR, JAR, ZIP, NONE}. Optional, default value is WAR.
 warFile | false | Target war file to deploy. Not used for Web Apps for containers. Optional, if not specified, default war file output produced by 'war' plugin will be used.
 jarFile | false | Target jar file to deploy. Not used for Web Apps for containers. Optional, if not specified, default jar file output produced by 'bootJar' plugin will be used.
+deploymentSlot | false | Deployment slot name to use. For springboot1337/deploy the name you should enter is "deploy"
 contextPath | false | Url path
 
 

--- a/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/AzureWebAppExtension.java
+++ b/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/AzureWebAppExtension.java
@@ -1,12 +1,11 @@
 package lenala.azure.gradle.webapp;
 
+import com.microsoft.azure.management.appservice.PricingTier;
+import groovy.lang.Closure;
 import lenala.azure.gradle.webapp.configuration.AppService;
 import lenala.azure.gradle.webapp.configuration.Authentication;
 import lenala.azure.gradle.webapp.configuration.Deployment;
-import lenala.azure.gradle.webapp.configuration.DeploymentSlotDeployTarget;
 import lenala.azure.gradle.webapp.model.PricingTierEnum;
-import com.microsoft.azure.management.appservice.PricingTier;
-import groovy.lang.Closure;
 import org.gradle.api.Project;
 
 public class AzureWebAppExtension {

--- a/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/AzureWebAppExtension.java
+++ b/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/AzureWebAppExtension.java
@@ -130,4 +130,8 @@ public class AzureWebAppExtension {
     public void setAuthentication(Authentication authentication) {
         this.authentication = authentication;
     }
+
+    public void setDeployment(Deployment deployment) {
+        this.deployment = deployment;
+    }
 }

--- a/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/AzureWebAppExtension.java
+++ b/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/AzureWebAppExtension.java
@@ -3,6 +3,7 @@ package lenala.azure.gradle.webapp;
 import lenala.azure.gradle.webapp.configuration.AppService;
 import lenala.azure.gradle.webapp.configuration.Authentication;
 import lenala.azure.gradle.webapp.configuration.Deployment;
+import lenala.azure.gradle.webapp.configuration.DeploymentSlotDeployTarget;
 import lenala.azure.gradle.webapp.model.PricingTierEnum;
 import com.microsoft.azure.management.appservice.PricingTier;
 import groovy.lang.Closure;
@@ -84,5 +85,49 @@ public class AzureWebAppExtension {
     public void setDeployment(Closure closure) {
         deployment = new Deployment();
         project.configure(deployment, closure);
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public void setSubscriptionId(String subscriptionId) {
+        this.subscriptionId = subscriptionId;
+    }
+
+    public void setAppName(String appName) {
+        this.appName = appName;
+    }
+
+    public void setResourceGroup(String resourceGroup) {
+        this.resourceGroup = resourceGroup;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public void setAppServicePlanResourceGroup(String appServicePlanResourceGroup) {
+        this.appServicePlanResourceGroup = appServicePlanResourceGroup;
+    }
+
+    public void setAppServicePlanName(String appServicePlanName) {
+        this.appServicePlanName = appServicePlanName;
+    }
+
+    public void setPricingTier(PricingTierEnum pricingTier) {
+        this.pricingTier = pricingTier;
+    }
+
+    public void setStopAppDuringDeployment(boolean stopAppDuringDeployment) {
+        this.stopAppDuringDeployment = stopAppDuringDeployment;
+    }
+
+    public void setAppService(AppService appService) {
+        this.appService = appService;
+    }
+
+    public void setAuthentication(Authentication authentication) {
+        this.authentication = authentication;
     }
 }

--- a/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/DeployTask.java
+++ b/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/DeployTask.java
@@ -19,6 +19,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskExecutionException;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
@@ -99,7 +100,7 @@ public class DeployTask extends DefaultTask implements AuthConfiguration {
         getLogger().quiet("Processing settings");
         getFactory().getSettingsHandler(getProject()).processSettings(withCreate);
         getLogger().quiet("Creating WebApp");
-        withCreate.create();
+        this.app = withCreate.create();
 
         getLogger().quiet(WEBAPP_CREATED);
     }
@@ -112,6 +113,7 @@ public class DeployTask extends DefaultTask implements AuthConfiguration {
         update.apply();
 
         getLogger().quiet(UPDATE_WEBAPP_DONE);
+        this.app = app;
     }
 
     private void deployArtifacts() throws Exception {

--- a/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/configuration/AppService.java
+++ b/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/configuration/AppService.java
@@ -57,4 +57,45 @@ public class AppService {
     public String getRegistryUrl() {
         return this.registryUrl;
     }
+
+    public void setType(AppServiceType type) {
+        this.type = type;
+    }
+
+    public void setRuntimeStack(String runtimeStack) {
+        this.runtimeStack = runtimeStack;
+    }
+
+    public void setJavaWebContainer(String javaWebContainer) {
+        this.javaWebContainer = javaWebContainer;
+    }
+
+    public void setJavaVersion(String javaVersion) {
+        this.javaVersion = javaVersion;
+    }
+
+    public void setImageName(String imageName) {
+        this.imageName = imageName;
+    }
+
+    public void setStartUpFile(String startUpFile) {
+        this.startUpFile = startUpFile;
+    }
+
+    public void setServerId(String serverId) {
+        this.serverId = serverId;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public void setRegistryUrl(String registryUrl) {
+        this.registryUrl = registryUrl;
+    }
+
 }

--- a/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/configuration/Authentication.java
+++ b/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/configuration/Authentication.java
@@ -42,4 +42,36 @@ public class Authentication {
     public String getCertificatePassword() {
         return certificatePassword;
     }
+
+    public void setType(AuthenticationType type) {
+        this.type = type;
+    }
+
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    public void setClient(String client) {
+        this.client = client;
+    }
+
+    public void setTenant(String tenant) {
+        this.tenant = tenant;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public void setCertificate(String certificate) {
+        this.certificate = certificate;
+    }
+
+    public void setCertificatePassword(String certificatePassword) {
+        this.certificatePassword = certificatePassword;
+    }
+
+    public void setEnvironment(String environment) {
+        this.environment = environment;
+    }
 }

--- a/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/configuration/Deployment.java
+++ b/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/configuration/Deployment.java
@@ -47,4 +47,28 @@ public class Deployment {
     public String getContextPath() {
         return StringUtils.isEmpty(this.contextPath) ? "" : this.contextPath;
     }
+
+    public void setType(DeploymentType type) {
+        this.type = type;
+    }
+
+    public void setWarFile(String warFile) {
+        this.warFile = warFile;
+    }
+
+    public void setJarFile(String jarFile) {
+        this.jarFile = jarFile;
+    }
+
+    public void setContextPath(String contextPath) {
+        this.contextPath = contextPath;
+    }
+
+    public void setDeploymentSlot(String deploymentSlot) {
+        this.deploymentSlot = deploymentSlot;
+    }
+
+    public void setFTPResources(List<FTPResource> resources) {
+        this.resources = resources;
+    }
 }

--- a/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/configuration/FTPResource.java
+++ b/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/configuration/FTPResource.java
@@ -13,4 +13,12 @@ public class FTPResource {
     public String getTargetPath() {
         return StringUtils.isEmpty(targetPath) ? "" : targetPath;
     }
+
+    public void setSourcePath(String sourcePath) {
+        this.sourcePath = sourcePath;
+    }
+
+    public void setTargetPath(String targetPath) {
+        this.targetPath = targetPath;
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 group                 = lenala.azure
-version               = 1.0
+version               = 1.0.1
 sourceCompatibility   = 1.8
 targetCompatibility   = 1.8
 


### PR DESCRIPTION
Hi!

First of all: thanks for enabling us to use Gradle to deploy projects to Azure!

During experimentation with deployment slots I noticed a NullPointerException caused by the fact that the app field is never set - this is fixed with this Pull Request. I also added documentation for setting deployment slots.

Also I added setters + getters to the configuration. This enables users of Kotlin Gradle DSL to configure the extension as well:


```kotlin
configure<AzureWebAppExtension> {
    resourceGroup = "..."
    appName = "..."
    setPricingTier(PricingTierEnum.F1)
    region = "westeurope"

    appService = AppService().apply {
        type = AppServiceType.WINDOWS
        setJavaWebContainer("tomcat 8.5")
        setJavaVersion("1.8.0_181")
    }

    authentication = Authentication().apply {
        type = AuthenticationType.AZURECLI
    }

    deployment = Deployment().apply {
        //deploymentSlot = "deploy"
        type = DeploymentType.JAR
    }
}
```