### PR TITLE
Add MSI support for app service and functions plugins.

### DIFF
--- a/azure-functions-gradle-plugin/src/main/java/lenala/azure/gradle/functions/auth/AzureAuthHelper.java
+++ b/azure-functions-gradle-plugin/src/main/java/lenala/azure/gradle/functions/auth/AzureAuthHelper.java
@@ -240,4 +240,8 @@ public class AzureAuthHelper {
         }
         return null;
     }
+
+    private static boolean isInCloudShell() {
+        return System.getenv(CLOUD_SHELL_ENV_KEY) != null;
+    }
 }

--- a/azure-functions-gradle-plugin/src/main/java/lenala/azure/gradle/functions/auth/AzureAuthHelper.java
+++ b/azure-functions-gradle-plugin/src/main/java/lenala/azure/gradle/functions/auth/AzureAuthHelper.java
@@ -26,6 +26,7 @@ public class AzureAuthHelper {
     private static final String CERTIFICATE = "certificate";
     private static final String CERTIFICATE_PASSWORD = "certificatePassword";
     private static final String ENVIRONMENT = "environment";
+    private static final String CLOUD_SHELL_ENV_KEY = "ACC_CLOUD";
 
     private static final String AUTH_WITH_CLIENT_ID = "Authenticate with clientId: ";
     private static final String AUTH_WITH_FILE = "Authenticate with file: ";

--- a/azure-functions-gradle-plugin/src/main/java/lenala/azure/gradle/functions/auth/AzureAuthHelper.java
+++ b/azure-functions-gradle-plugin/src/main/java/lenala/azure/gradle/functions/auth/AzureAuthHelper.java
@@ -3,6 +3,7 @@ package lenala.azure.gradle.functions.auth;
 import com.microsoft.azure.AzureEnvironment;
 import com.microsoft.azure.credentials.ApplicationTokenCredentials;
 import com.microsoft.azure.credentials.AzureCliCredentials;
+import com.microsoft.azure.credentials.MSICredentials;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.Azure.Authenticated;
 import com.microsoft.rest.LogLevel;
@@ -29,6 +30,7 @@ public class AzureAuthHelper {
     private static final String AUTH_WITH_CLIENT_ID = "Authenticate with clientId: ";
     private static final String AUTH_WITH_FILE = "Authenticate with file: ";
     private static final String AUTH_WITH_AZURE_CLI = "Authenticate with Azure CLI 2.0";
+    private static final String AUTH_WITH_AZURE_MSI = "Authenticate with Azure CLI 2.0 via MSI";
     private static final String USE_KEY_TO_AUTH = "Use key to get Azure authentication token: ";
     private static final String USE_CERTIFICATE_TO_AUTH = "Use certificate to get Azure authentication token.";
 
@@ -171,9 +173,18 @@ public class AzureAuthHelper {
      */
     private Authenticated getAuthObjFromAzureCli() {
         try {
-            final Authenticated auth = azureConfigure().authenticate(AzureCliCredentials.create());
-            if (auth != null) {
-                logger.quiet(AUTH_WITH_AZURE_CLI);
+            final Azure.Configurable azureConfigurable = azureConfigure();
+            final Authenticated auth;
+            if (isInCloudShell()) {
+                auth = azureConfigurable.authenticate(new MSICredentials());
+                if (auth != null) {
+                    logger.quiet(AUTH_WITH_AZURE_MSI);
+                }                
+            } else {
+                auth = azureConfigurable.authenticate(AzureCliCredentials.create());
+                if (auth != null) {
+                    logger.quiet(AUTH_WITH_AZURE_CLI);
+                }
             }
             return auth;
         } catch (Exception e) {

--- a/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/auth/AzureAuthHelper.java
+++ b/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/auth/AzureAuthHelper.java
@@ -24,6 +24,8 @@ import static lenala.azure.gradle.webapp.helpers.CommonStringTemplates.PROPERTY_
  * Helper class to authenticate with Azure.
  */
 public class AzureAuthHelper {
+    private static final String CLOUD_SHELL_ENV_KEY = "ACC_CLOUD";
+
     private static final String AUTH_WITH_CLIENT_ID = "Authenticate with clientId: ";
     private static final String AUTH_WITH_FILE = "Authenticate with file: ";
     private static final String AUTH_WITH_AZURE_CLI = "Authenticate with Azure CLI 2.0";

--- a/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/auth/AzureAuthHelper.java
+++ b/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/auth/AzureAuthHelper.java
@@ -3,6 +3,7 @@ package lenala.azure.gradle.webapp.auth;
 import com.microsoft.azure.AzureEnvironment;
 import com.microsoft.azure.credentials.ApplicationTokenCredentials;
 import com.microsoft.azure.credentials.AzureCliCredentials;
+import com.microsoft.azure.credentials.MSICredentials;
 import lenala.azure.gradle.webapp.configuration.Authentication;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.Azure.Authenticated;
@@ -26,6 +27,7 @@ public class AzureAuthHelper {
     private static final String AUTH_WITH_CLIENT_ID = "Authenticate with clientId: ";
     private static final String AUTH_WITH_FILE = "Authenticate with file: ";
     private static final String AUTH_WITH_AZURE_CLI = "Authenticate with Azure CLI 2.0";
+    private static final String AUTH_WITH_AZURE_MSI = "Authenticate with Azure CLI 2.0 via MSI";
     private static final String USE_KEY_TO_AUTH = "Use key to get Azure authentication token: ";
     private static final String USE_CERTIFICATE_TO_AUTH = "Use certificate to get Azure authentication token.";
     private static final String CERTIFICATE_FILE_READ_FAIL = "Failed to read certificate file: ";
@@ -169,9 +171,18 @@ public class AzureAuthHelper {
      */
     private Authenticated getAuthObjFromAzureCli() {
         try {
-            final Authenticated auth = azureConfigure().authenticate(AzureCliCredentials.create());
-            if (auth != null) {
-                logger.quiet(AUTH_WITH_AZURE_CLI);
+            final Azure.Configurable azureConfigurable = azureConfigure();
+            final Authenticated auth;
+            if (isInCloudShell()) {
+                auth = azureConfigurable.authenticate(new MSICredentials());
+                if (auth != null) {
+                    logger.quiet(AUTH_WITH_AZURE_MSI);
+                }                
+            } else {
+                auth = azureConfigurable.authenticate(AzureCliCredentials.create());
+                if (auth != null) {
+                    logger.quiet(AUTH_WITH_AZURE_CLI);
+                }
             }
             return auth;
         } catch (Exception e) {

--- a/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/auth/AzureAuthHelper.java
+++ b/azure-webapp-gradle-plugin/src/main/java/lenala/azure/gradle/webapp/auth/AzureAuthHelper.java
@@ -238,4 +238,8 @@ public class AzureAuthHelper {
         }
         return null;
     }
+
+    private static boolean isInCloudShell() {
+        return System.getenv(CLOUD_SHELL_ENV_KEY) != null;
+    }
 }


### PR DESCRIPTION
These changes are similar to the changes in the Maven plugin PR:

https://github.com/microsoft/azure-maven-plugins/pull/558/files

I'm using this Gradle plugin, but need MSI support.  Thanks for reviewing/considering!

I could not tell if the version of the Azure package being used in this plugin is high enough to have the MSICredentials class.  